### PR TITLE
Assign stable keys to AnimatedPaintStripe widgets

### DIFF
--- a/lib/screens/roller_screen.dart
+++ b/lib/screens/roller_screen.dart
@@ -1032,14 +1032,9 @@ class _RollerScreenState extends RollerScreenStatePublic {
         final paint = i < palette.length ? palette[i] : null;
         final isLocked = i < _lockedStates.length ? _lockedStates[i] : false;
         
-        // Create a more stable key that doesn't change when paint is null
-        final keyString = paint != null 
-            ? '${paint.id}|${paint.hex}|$i' 
-            : 'empty_$i';
-            
         return Expanded(
           child: AnimatedPaintStripe(
-            key: ValueKey(keyString),
+            key: ValueKey(paint?.id ?? 'empty_$i'),
             paint: paint,
             previousPaint: null,
             isLocked: isLocked,


### PR DESCRIPTION
## Summary
- use `ValueKey(paint?.id ?? 'empty_$i')` for each `AnimatedPaintStripe` to keep stable identity

## Testing
- `flutter test` *(fails: command not found)*
- `flutter run -d web-server` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e9fd82188322afe76845f3a575a5