### PR TITLE
feat(plan): introduce ColorPlan domain, service, screens, + V2 function (non-breaking)

### DIFF
--- a/lib/screens/color_plan_detail_screen.dart
+++ b/lib/screens/color_plan_detail_screen.dart
@@ -24,10 +24,16 @@ import '../widgets/gradient_fallback_hero.dart';
 import '../utils/gradient_hero_utils.dart';
 import '../screens/visualizer_screen.dart';
 import 'color_plan_screen.dart';
+// REGION: CODEX-ADD color-plan-detail-screen-imports
+import '../services/color_plan_service.dart';
+// END REGION: CODEX-ADD color-plan-detail-screen-imports
 
 class ColorPlanDetailScreen extends StatefulWidget {
   final String storyId;
-  const ColorPlanDetailScreen({super.key, required this.storyId});
+  // REGION: CODEX-ADD color-plan-detail-screen
+  final String? projectId;
+  const ColorPlanDetailScreen({super.key, required this.storyId, this.projectId});
+  // END REGION: CODEX-ADD color-plan-detail-screen
   @override
   State<ColorPlanDetailScreen> createState() => _ColorPlanDetailScreenState();
 }
@@ -41,6 +47,9 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
   bool _showTranscript = false;
   bool _wifiOnlyAssets = false;
   bool _processingTimedOut = false;
+  // REGION: CODEX-ADD color-plan-detail-screen-state
+  ColorPlan? _plan;
+  // END REGION: CODEX-ADD color-plan-detail-screen-state
 
   // Ambient audio
   final _ambientController = AmbientLoopController();
@@ -75,6 +84,13 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
     super.initState();
     _checkLikeStatus();
     _loadUserPreferences();
+    // REGION: CODEX-ADD color-plan-detail-screen-init
+    if (widget.projectId != null) {
+      ColorPlanService().getPlan(widget.projectId!, widget.storyId).then((p) {
+        if (mounted) setState(() => _plan = p);
+      });
+    }
+    // END REGION: CODEX-ADD color-plan-detail-screen-init
 
     // Check for processing timeout after 2 minutes
     Future.delayed(const Duration(minutes: 2), () {
@@ -1114,7 +1130,16 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                         ],
                       ),
                     ),
-
+                  // REGION: CODEX-ADD color-plan-detail-screen
+                  if (_plan != null) ...[
+                    _buildPlacementMapSection(_plan!),
+                    _buildCohesionTipsSection(_plan!),
+                    _buildAccentRulesSection(_plan!),
+                    _buildDoDontSection(_plan!),
+                    _buildSampleSequenceSection(_plan!),
+                    _buildRoomPlaybookSection(_plan!),
+                  ],
+                  // END REGION: CODEX-ADD color-plan-detail-screen
                   // Contrast Coaching section
                   if (story.status == 'complete' && story.usageGuide.isNotEmpty)
                     Container(
@@ -1330,6 +1355,105 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
           );
         });
   }
+
+  // REGION: CODEX-ADD color-plan-detail-screen-methods
+  Widget _section(String title, List<Widget> children) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color:
+              Theme.of(context).colorScheme.outline.withValues(alpha: 0.1),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context)
+                .textTheme
+                .titleLarge
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlacementMapSection(ColorPlan plan) {
+    if (plan.placementMap.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Placement Map',
+      plan.placementMap
+          .map((p) => Text('${p.area}: ${p.colorId} (${p.sheen})'))
+          .toList(),
+    );
+  }
+
+  Widget _buildCohesionTipsSection(ColorPlan plan) {
+    if (plan.cohesionTips.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Cohesion Tips',
+      plan.cohesionTips.map((t) => Text('\u2022 ' + t)).toList(),
+    );
+  }
+
+  Widget _buildAccentRulesSection(ColorPlan plan) {
+    if (plan.accentRules.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Accent Rules',
+      plan.accentRules
+          .map((a) => Text('${a.context}: ${a.guidance}'))
+          .toList(),
+    );
+  }
+
+  Widget _buildDoDontSection(ColorPlan plan) {
+    if (plan.doDont.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Do & Don\'t',
+      plan.doDont
+          .map((d) =>
+              Text('Do: ${d.doText}\nDon\'t: ${d.dontText}'))
+          .toList(),
+    );
+  }
+
+  Widget _buildSampleSequenceSection(ColorPlan plan) {
+    if (plan.sampleSequence.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Sample Sequence',
+      plan.sampleSequence.map((s) => Text('\u2022 ' + s)).toList(),
+    );
+  }
+
+  Widget _buildRoomPlaybookSection(ColorPlan plan) {
+    if (plan.roomPlaybook.isEmpty) return const SizedBox.shrink();
+    return _section(
+      'Room Playbook',
+      plan.roomPlaybook
+          .map(
+            (r) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(r.roomType,
+                    style: Theme.of(context).textTheme.titleMedium),
+                ...r.placements.map(
+                    (p) => Text(' - ${p.area}: ${p.colorId} (${p.sheen})')),
+                if (r.notes.isNotEmpty) Text(r.notes),
+              ],
+            ),
+          )
+          .toList(),
+    );
+  }
+  // END REGION: CODEX-ADD color-plan-detail-screen-methods
 
   Widget _buildVariantCard(ColorStory variant, int index) {
     return Container(

--- a/lib/screens/color_plan_screen.dart
+++ b/lib/screens/color_plan_screen.dart
@@ -11,6 +11,9 @@ import 'package:color_canvas/services/analytics_service.dart';
 import 'color_plan_detail_screen.dart';
 import 'package:color_canvas/screens/settings_screen.dart';
 import 'package:color_canvas/utils/color_utils.dart';
+// REGION: CODEX-ADD color-plan-screen-imports
+import 'package:color_canvas/models/color_plan.dart';
+// END REGION: CODEX-ADD color-plan-screen-imports
 
 class ColorPlanScreen extends StatefulWidget {
   final String projectId;
@@ -1193,7 +1196,35 @@ class _ColorPlanScreenState extends State<ColorPlanScreen> {
     );
   }
 
-// ...existing code...
+// REGION: CODEX-ADD color-plan-screen
+  Widget _buildPlanPreview(ColorPlan plan) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (plan.placementMap.isNotEmpty)
+          Text('Placements: ' +
+              plan.placementMap
+                  .map((p) => '${p.area}-${p.colorId}')
+                  .join(', ')),
+        if (plan.cohesionTips.isNotEmpty)
+          Text('Cohesion: ' + plan.cohesionTips.join('; ')),
+        if (plan.accentRules.isNotEmpty)
+          Text('Accent: ' +
+              plan.accentRules
+                  .map((a) => '${a.context}: ${a.guidance}')
+                  .join('; ')),
+        if (plan.doDont.isNotEmpty)
+          Text(
+              'Do: ${plan.doDont.first.doText}\nDon\'t: ${plan.doDont.first.dontText}'),
+        if (plan.sampleSequence.isNotEmpty)
+          Text('Sequence: ' + plan.sampleSequence.join(' -> ')),
+        if (plan.roomPlaybook.isNotEmpty)
+          Text('Rooms: ' +
+              plan.roomPlaybook.map((r) => r.roomType).join(', ')),
+      ],
+    );
+  }
+// END REGION: CODEX-ADD color-plan-screen
 
   @override
   void dispose() {

--- a/tooling/migrate_stories_to_plans.dart
+++ b/tooling/migrate_stories_to_plans.dart
@@ -5,31 +5,39 @@ import '../lib/models/color_plan.dart';
 Future<void> main() async {
   await Firebase.initializeApp();
   final db = FirebaseFirestore.instance;
+  int migrated = 0;
   final users = await db.collection('users').get();
   for (final u in users.docs) {
     final projects = await u.reference.collection('projects').get();
     for (final p in projects.docs) {
       final stories = await p.reference.collection('colorStories').get();
       for (final s in stories.docs) {
+        final planRef = p.reference.collection('colorPlans').doc(s.id);
+        final exists = await planRef.get();
+        if (exists.exists) continue;
+
         final data = s.data();
-        final planRef = p.reference.collection('colorPlans').doc();
         final plan = ColorPlan.fromJson(planRef.id, {
           'projectId': p.id,
-          'name': data['name'] ?? 'Plan',
+          'name': data['name'] ?? data['title'] ?? 'Plan',
           'vibe': data['vibe'] ?? '',
-          'paletteColorIds': (data['palette'] ?? []).cast<String>(),
-          'placementMap': (data['placements'] ?? []),
-          'cohesionTips': (data['tips'] ?? []),
-          'accentRules': (data['accents'] ?? []),
+          'paletteColorIds':
+              (data['paletteColorIds'] ?? data['palette'] ?? []).cast<String>(),
+          'placementMap': (data['placementMap'] ?? data['placements'] ?? []),
+          'cohesionTips': (data['cohesionTips'] ?? data['tips'] ?? []),
+          'accentRules': (data['accentRules'] ?? data['accents'] ?? []),
           'doDont': (data['doDont'] ?? []),
-          'sampleSequence': (data['sequence'] ?? []),
-          'roomPlaybook': (data['rooms'] ?? []),
-          'createdAt': Timestamp.now(),
-          'updatedAt': Timestamp.now(),
+          'sampleSequence':
+              (data['sampleSequence'] ?? data['sequence'] ?? []),
+          'roomPlaybook': (data['roomPlaybook'] ?? data['rooms'] ?? []),
+          'createdAt': data['createdAt'] ?? Timestamp.now(),
+          'updatedAt': data['updatedAt'] ?? Timestamp.now(),
         });
         await planRef.set(plan.toJson());
+        migrated++;
         print('Migrated story ${s.id} -> plan ${planRef.id}');
       }
     }
   }
+  print('Total migrated plans: $migrated');
 }


### PR DESCRIPTION
## Summary
- add Cloud Function `generateColorPlanV2` that synthesizes placement maps, rules, and tips
- build `ColorPlanService` with CRUD operations and analytics hook
- show ColorPlan details on screen, including placements, tips, accents, dos/don'ts, sequence, and room playbook
- provide migration script for one-time copy from color stories to color plans

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./index.js')"` *(fails: Cannot find module 'firebase-functions')*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e1f801f8832283a7da1405b8d67b