### PR TITLE
feat(plan): Painter Pack PDF export with SKU/sheens + swatch cards

### DIFF
--- a/lib/screens/color_plan_detail_screen.dart
+++ b/lib/screens/color_plan_detail_screen.dart
@@ -554,40 +554,57 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                 ],
               ),
               actions: [
+                // REGION: CODEX-ADD painter-pack-export-action
                 IconButton(
                   icon: const Icon(Icons.picture_as_pdf),
                   tooltip: 'Export Painter Pack',
                   onPressed: () async {
-                    final plan = ColorPlan(
-                      id: story.id,
-                      projectId: story.userId,
-                      name: story.title,
-                      vibe: story.vibeWords.join(', '),
-                      paletteColorIds: story.palette
-                          .map((c) => c.paintId ?? c.hex)
-                          .toList(),
-                      placementMap: [],
-                      cohesionTips: [],
-                      accentRules: [],
-                      doDont: [],
-                      sampleSequence: [],
-                      roomPlaybook: [],
-                      createdAt: DateTime.now(),
-                      updatedAt: DateTime.now(),
-                    );
-                    final pdf =
-                        await PainterPackService().buildPdf(plan, {});
+                    final plan = _plan ??
+                        ColorPlan(
+                          id: story.id,
+                          projectId: story.userId,
+                          name: story.title,
+                          vibe: story.vibeWords.join(', '),
+                          paletteColorIds: story.palette
+                              .map((c) => c.paintId ?? c.hex)
+                              .toList(),
+                          placementMap: [],
+                          cohesionTips: [],
+                          accentRules: [],
+                          doDont: [],
+                          sampleSequence: [],
+                          roomPlaybook: [],
+                          createdAt: DateTime.now(),
+                          updatedAt: DateTime.now(),
+                        );
+
+                    final skuMap = {
+                      for (final c in story.palette)
+                        (c.paintId ?? c.hex): schema.PaletteColor(
+                          paintId: c.paintId ?? c.hex,
+                          locked: false,
+                          position: 0,
+                          brand: c.brandName ?? '',
+                          name: c.name ?? '',
+                          code: c.code ?? '',
+                          hex: c.hex,
+                        )
+                    };
+
+                    final service = PainterPackService();
+                    final pdfBytes = await service.buildPdf(plan, skuMap);
                     await Printing.layoutPdf(
-                        onLayout: (_) async => pdf);
+                        onLayout: (_) async => pdfBytes);
                     await AnalyticsService.instance.logEvent(
                       'painter_pack_exported',
                       {
-                        'pageCount': 1,
+                        'pageCount': service.lastPageCount,
                         'colorCount': plan.paletteColorIds.length,
                       },
                     );
                   },
                 ),
+                // END REGION: CODEX-ADD painter-pack-export-action
                 IconButton(
                   tooltip: _colorBlindOn
                       ? 'Disable color-blind sim'


### PR DESCRIPTION
## Summary
- add `PainterPackService` to build Painter Pack PDFs including SKU/sheens table, placement lists, do/don't tips, and swatch cards
- integrate Painter Pack export action on Color Plan detail screen with region markers and analytics

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e40a769883229435af02e0d4984f