### PR TITLE
feat(core): wire core loop CTAs across Roller and Project Overview

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,9 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ai/firebase_ai.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:color_canvas/screens/compare_screen.dart';
+// REGION: CODEX-ADD compare-colors-import
+import 'package:color_canvas/screens/compare_colors_screen.dart';
+// END REGION: CODEX-ADD compare-colors-import
 import 'package:color_canvas/widgets/more_menu_sheet.dart';
 import 'package:color_canvas/firebase_config.dart';
 import 'package:color_canvas/theme.dart';
@@ -139,11 +142,12 @@ class MyApp extends StatelessWidget {
             '/home': (context) => const HomeScreen(),
             '/login': (context) => const LoginScreen(),
             '/colorPlan': (context) {
-              final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
+              final args =
+                  ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
               return ColorPlanScreen(
                 projectId: args['projectId'] as String,
-                paletteId: args['paletteId'] as String?,
-                remixStoryId: args['remixStoryId'] as String?
+                paletteColorIds:
+                    (args['paletteColorIds'] as List<dynamic>?)?.cast<String>(),
               );
             },
             '/visualize': (context) {
@@ -159,6 +163,15 @@ class MyApp extends StatelessWidget {
                 comparePalette: args?['palette']
               );
             },
+            // REGION: CODEX-ADD compare-colors-route
+            '/compareColors': (context) {
+              final args =
+                  ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
+              final ids =
+                  (args['paletteColorIds'] as List<dynamic>? ?? []).cast<String>();
+              return CompareColorsScreen(paletteColorIds: ids);
+            },
+            // END REGION: CODEX-ADD compare-colors-route
             '/colorPlanDetail': (context) {
               final storyId =
                   ModalRoute.of(context)!.settings.arguments as String;

--- a/lib/screens/project_overview_screen.dart
+++ b/lib/screens/project_overview_screen.dart
@@ -16,6 +16,7 @@ class ProjectOverviewScreen extends StatelessWidget {
   // Use the project's stored palette ids. If a ColorStory object is needed
   // later, it should be fetched separately; ProjectDoc only stores a colorStoryId.
   final List<String> paletteIds = project.paletteIds;
+  final bool hasPalette = paletteIds.isNotEmpty;
 
     return Scaffold(
       appBar: AppBar(
@@ -26,17 +27,19 @@ class ProjectOverviewScreen extends StatelessWidget {
             padding: const EdgeInsets.all(12.0),
             child: Row(children: [
               Expanded(child: ElevatedButton.icon(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/colorPlan', arguments: {
-                    'projectId': project.id, 
-                    'paletteColorIds': paletteIds
-                  });
-                  AnalyticsService.instance.logEvent(
-                    'cta_plan_clicked',
-                    {'source': 'project_overview', 'project_id': project.id},
-                  );
-                },
-                icon: const Icon(Icons.auto_awesome), 
+                onPressed: hasPalette
+                    ? () {
+                        Navigator.pushNamed(context, '/colorPlan', arguments: {
+                          'projectId': project.id,
+                          'paletteColorIds': paletteIds
+                        });
+                        AnalyticsService.instance.logEvent(
+                          'cta_plan_clicked',
+                          {'source': 'project_overview', 'project_id': project.id},
+                        );
+                      }
+                    : null,
+                icon: const Icon(Icons.auto_awesome),
                 label: const Text('Make a Color Plan'),
               )),
               const SizedBox(width: 8),
@@ -56,15 +59,18 @@ class ProjectOverviewScreen extends StatelessWidget {
               )),
               const SizedBox(width: 8),
               IconButton(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/compareColors', arguments: {
-                    'paletteColorIds': paletteIds
-                  });
-                  AnalyticsService.instance.logEvent(
-                    'cta_compare_clicked',
-                    {'source': 'project_overview', 'project_id': project.id},
-                  );
-                }, 
+                onPressed: hasPalette
+                    ? () {
+                        Navigator.pushNamed(context, '/compareColors', arguments: {
+                          'projectId': project.id,
+                          'paletteColorIds': paletteIds
+                        });
+                        AnalyticsService.instance.logEvent(
+                          'cta_compare_clicked',
+                          {'source': 'project_overview', 'project_id': project.id},
+                        );
+                      }
+                    : null,
                 icon: const Icon(Icons.compare)
               ),
             ]),


### PR DESCRIPTION
## Summary
- add Plan/Visualize/Compare CTA bar in Roller
- extend Project Overview with same CTA row and palette-aware disabling
- register CompareColors route and pass palette ids across navigation

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e5612f488322a6d66fd539545aa6