### PR TITLE
feat(roller): one-tap palette variants with history

### DIFF
--- a/lib/services/project_service.dart
+++ b/lib/services/project_service.dart
@@ -121,4 +121,22 @@ class ProjectService {
     if (!snap.exists) return null;
     return ProjectDoc.fromSnap(snap);
   }
+
+  static Future<void> addPaletteHistory(
+      String projectId, String kind, List<String> palette) async {
+    final uid = _uid;
+    if (uid == null) {
+      throw Exception('Sign in required to update projects');
+    }
+
+    try {
+      await _col.doc(projectId).collection('paletteHistory').add({
+        'kind': kind,
+        'palette': palette,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+    } catch (e) {
+      debugPrint('ProjectService: Failed to append palette history: $e');
+    }
+  }
 }

--- a/lib/utils/palette_transforms.dart
+++ b/lib/utils/palette_transforms.dart
@@ -12,7 +12,7 @@ typedef ColorId = String;
 typedef LabLookup = Lab Function(ColorId id);
 
 /// Given a Lab value, return the nearest catalog color id.
-typedef NearestId = ColorId Function(Lab lab);
+typedef NearestId = ColorId? Function(Lab lab);
 
 List<ColorId> softer(
   List<ColorId> ids,
@@ -22,13 +22,14 @@ List<ColorId> softer(
   return ids
       .map((id) {
         final lab = labOf(id);
-        return nearestId(
+        final nearest = nearestId(
           Lab(
             math.min(100.0, lab.l + 5.0),
             lab.a * 0.9,
             lab.b * 0.9,
           ),
         );
+        return nearest ?? id;
       })
       .toList(growable: false);
 }
@@ -41,13 +42,14 @@ List<ColorId> brighter(
   return ids
       .map((id) {
         final lab = labOf(id);
-        return nearestId(
+        final nearest = nearestId(
           Lab(
             math.min(100.0, lab.l + 10.0),
             lab.a,
             lab.b,
           ),
         );
+        return nearest ?? id;
       })
       .toList(growable: false);
 }
@@ -60,13 +62,14 @@ List<ColorId> moodier(
   return ids
       .map((id) {
         final lab = labOf(id);
-        return nearestId(
+        final nearest = nearestId(
           Lab(
             math.max(0.0, lab.l - 10.0),
             lab.a,
             lab.b,
           ),
         );
+        return nearest ?? id;
       })
       .toList(growable: false);
 }
@@ -79,13 +82,14 @@ List<ColorId> warmer(
   return ids
       .map((id) {
         final lab = labOf(id);
-        return nearestId(
+        final nearest = nearestId(
           Lab(
             lab.l,
             lab.a + 4.0,
             lab.b - 2.0,
           ),
         );
+        return nearest ?? id;
       })
       .toList(growable: false);
 }
@@ -98,13 +102,14 @@ List<ColorId> cooler(
   return ids
       .map((id) {
         final lab = labOf(id);
-        return nearestId(
+        final nearest = nearestId(
           Lab(
             lab.l,
             lab.a - 4.0,
             lab.b + 2.0,
           ),
         );
+        return nearest ?? id;
       })
       .toList(growable: false);
 }


### PR DESCRIPTION
## Summary
- add LAB-based palette transform helpers for one-tap variants
- persist applied variants to project palette history
- expose variant ActionChips in Roller with analytics and history persistence

## Testing
- `dart format lib/utils/palette_transforms.dart lib/services/project_service.dart lib/screens/roller_screen.dart` *(fails: command not found)*
- `flutter format lib/utils/palette_transforms.dart lib/services/project_service.dart lib/screens/roller_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e69bec5c83228e52108838fc1d9e