### PR TITLE
feat(search): companions model + 2–4 color compare

### DIFF
--- a/lib/models/paint.dart
+++ b/lib/models/paint.dart
@@ -1,18 +1,40 @@
 // lib/models/paint.dart
 class PaintColor {
-  final String id; final String brand; final String name; final double lrv; final String undertone;
-  final List<String> similarIds; final List<String> companionIds;
+  final String id;
+  final String brand;
+  final String name;
+  final double lrv;
+  final String undertone;
+  final List<String>? similarIds;
+  final List<String>? companionIds;
+
   const PaintColor({
-    required this.id, required this.brand, required this.name, required this.lrv, required this.undertone,
-    this.similarIds = const [], this.companionIds = const [],
+    required this.id,
+    required this.brand,
+    required this.name,
+    required this.lrv,
+    required this.undertone,
+    this.similarIds,
+    this.companionIds,
   });
+
   factory PaintColor.fromJson(Map<String, dynamic> j) => PaintColor(
-    id: j['id'], brand: j['brand'], name: j['name'], lrv: (j['lrv'] ?? 0).toDouble(), undertone: j['undertone'] ?? 'neutral',
-    similarIds: (j['similarIds'] as List<dynamic>? ?? []).cast<String>(),
-    companionIds: (j['companionIds'] as List<dynamic>? ?? []).cast<String>(),
-  );
+        id: j['id'] as String,
+        brand: j['brand'] as String,
+        name: j['name'] as String,
+        lrv: (j['lrv'] ?? 0).toDouble(),
+        undertone: j['undertone'] ?? 'neutral',
+        similarIds: (j['similarIds'] as List?)?.cast<String>(),
+        companionIds: (j['companionIds'] as List?)?.cast<String>(),
+      );
+
   Map<String, dynamic> toJson() => {
-    'id': id, 'brand': brand, 'name': name, 'lrv': lrv, 'undertone': undertone,
-    'similarIds': similarIds, 'companionIds': companionIds,
-  };
+        'id': id,
+        'brand': brand,
+        'name': name,
+        'lrv': lrv,
+        'undertone': undertone,
+        if (similarIds != null) 'similarIds': similarIds,
+        if (companionIds != null) 'companionIds': companionIds,
+      };
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -8,6 +8,7 @@ import 'package:color_canvas/screens/paint_detail_screen.dart';
 import 'package:color_canvas/screens/compare_colors_screen.dart';
 import 'package:color_canvas/utils/debug_logger.dart';
 import 'dart:async';
+import 'package:color_canvas/services/analytics_service.dart';
 // ...existing code...
 
 class SearchScreen extends StatefulWidget {
@@ -297,6 +298,9 @@ class _SearchScreenState extends State<SearchScreen> {
       floatingActionButton: _selectedForCompare.length >= 2
           ? FloatingActionButton.extended(
               onPressed: () {
+                AnalyticsService.instance.logEvent('compare_opened', {
+                  'count': _selectedForCompare.length,
+                });
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) => CompareColorsScreen(


### PR DESCRIPTION
## Summary
- add companionIds and similarIds to PaintColor with JSON parsing
- introduce CompareColorsScreen to show swatches and LRV/contrast table for up to four paints
- log compare_opened telemetry from Search screen

## Testing
- `dart format lib/models/paint.dart lib/screens/compare_colors_screen.dart lib/screens/search_screen.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ea8bf6d883229418a6035cc1d422