### PR TITLE
feat(via): assistant overlay + viaReply function (MVP)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -174,3 +174,23 @@ exports.generateColorPlanV1 = functions.https.onCall(async (data, context) => {
     roomPlaybook,
   };
 });
+
+exports.viaReply = functions.https.onCall((data) => {
+  const { context, state } = data || {};
+  const action = (state && state.action) || '';
+  let text;
+  switch (action.toLowerCase()) {
+    case 'explain':
+      text = `Explanation for ${context}`;
+      break;
+    case 'simplify':
+      text = `Simplified ${context}`;
+      break;
+    case 'budget':
+      text = `Budget advice for ${context}`;
+      break;
+    default:
+      text = `No suggestion for ${context}`;
+  }
+  return { text };
+});

--- a/lib/screens/color_plan_detail_screen.dart
+++ b/lib/screens/color_plan_detail_screen.dart
@@ -28,6 +28,7 @@ import 'color_plan_screen.dart';
 // REGION: CODEX-ADD color-plan-detail-screen-imports
 import '../services/color_plan_service.dart';
 // END REGION: CODEX-ADD color-plan-detail-screen-imports
+import '../widgets/via_overlay.dart';
 
 class ColorPlanDetailScreen extends StatefulWidget {
   final String storyId;
@@ -941,7 +942,9 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                     )
                   : null,
             ),
-            body: SingleChildScrollView(
+            body: Stack(
+              children: [
+                SingleChildScrollView(
               physics: const BouncingScrollPhysics(),
               child: Column(
                 children: [
@@ -1436,6 +1439,23 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                   ),
                 ],
               ),
+            ),
+                ViaOverlay(
+                  contextLabel: 'color_plan_detail',
+                  onVisualize: widget.projectId == null
+                      ? null
+                      : () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => VisualizerScreen(
+                                projectId: widget.projectId,
+                                storyId: widget.storyId,
+                              ),
+                            ),
+                          );
+                        },
+                ),
+              ],
             ),
           );
         });

--- a/lib/screens/roller_screen.dart
+++ b/lib/screens/roller_screen.dart
@@ -20,6 +20,9 @@ import 'package:color_canvas/services/analytics_service.dart';
 import 'package:color_canvas/utils/palette_transforms.dart' as transforms;
 import 'package:color_canvas/utils/lab.dart';
 import 'package:color_canvas/services/project_service.dart';
+import 'package:color_canvas/widgets/via_overlay.dart';
+import 'package:color_canvas/screens/color_plan_screen.dart';
+import 'package:color_canvas/screens/visualizer_screen.dart';
 
 // Custom intents for keyboard navigation
 class GoToPrevPageIntent extends Intent {
@@ -954,6 +957,34 @@ class _RollerScreenState extends RollerScreenStatePublic {
                     ],
                     panelBuilder: (tool) => _buildToolPanel(tool),
                   ),
+                ),
+                ViaOverlay(
+                  contextLabel: 'roller',
+                  onMakePlan: widget.projectId == null
+                      ? null
+                      : () {
+                          final ids =
+                              _currentPalette.map((p) => p.id).toList();
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => ColorPlanScreen(
+                                projectId: widget.projectId!,
+                                paletteColorIds: ids,
+                              ),
+                            ),
+                          );
+                        },
+                  onVisualize: widget.projectId == null
+                      ? null
+                      : () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => VisualizerScreen(
+                                projectId: widget.projectId,
+                              ),
+                            ),
+                          );
+                        },
                 ),
               ],
             ),

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -15,6 +15,8 @@ import '../firestore/firestore_data_schema.dart'; // for UserPalette
 import '../services/analytics_service.dart';
 import '../models/color_story.dart';
 import '../data/sample_rooms.dart';
+import '../widgets/via_overlay.dart';
+import 'color_plan_screen.dart';
 
 enum CompareMode { none, grid, split, slider }
 
@@ -381,10 +383,25 @@ class _VisualizerScreenState extends State<VisualizerScreen>
                     width: 52,
                     height: 52,
                     child: CircularProgressIndicator(strokeWidth: 4),
-                  ),
                 ),
               ),
             ),
+          ),
+          ViaOverlay(
+            contextLabel: 'visualizer',
+            onMakePlan: widget.projectId == null
+                ? null
+                : () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => ColorPlanScreen(
+                          projectId: widget.projectId!,
+                          paletteColorIds: const [],
+                        ),
+                      ),
+                    );
+                  },
+          ),
         ],
       ),
     );

--- a/lib/services/via_service.dart
+++ b/lib/services/via_service.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_functions/cloud_functions.dart';
+
+/// Service for interacting with the Via assistant cloud function.
+class ViaService {
+  static final ViaService _instance = ViaService._();
+  factory ViaService() => _instance;
+  ViaService._();
+
+  final _functions = FirebaseFunctions.instanceFor(region: 'us-central1');
+
+  /// Fetches a suggestion for the given [contextLabel] and [state].
+  Future<String> reply(String contextLabel, Map<String, dynamic> state) async {
+    final callable = _functions.httpsCallable('viaReply');
+    final resp = await callable.call({'context': contextLabel, 'state': state});
+    final data = Map<String, dynamic>.from(resp.data as Map);
+    return data['text'] as String? ?? '';
+  }
+}

--- a/lib/widgets/via_overlay.dart
+++ b/lib/widgets/via_overlay.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import '../services/via_service.dart';
+import '../services/analytics_service.dart';
+
+class ViaOverlay extends StatefulWidget {
+  final String contextLabel;
+  final Map<String, dynamic> state;
+  final VoidCallback? onMakePlan;
+  final VoidCallback? onVisualize;
+
+  const ViaOverlay({
+    super.key,
+    required this.contextLabel,
+    this.state = const {},
+    this.onMakePlan,
+    this.onVisualize,
+  });
+
+  @override
+  State<ViaOverlay> createState() => _ViaOverlayState();
+}
+
+class _ViaOverlayState extends State<ViaOverlay> {
+  bool _open = false;
+
+  void _toggle() => setState(() => _open = !_open);
+
+  Future<void> _handleText(String action) async {
+    final text = await ViaService().reply(widget.contextLabel, {
+      ...widget.state,
+      'action': action,
+    });
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(text)),
+    );
+    await AnalyticsService.instance
+        .logEvent('via_action_clicked', {'action': action});
+  }
+
+  void _handleNav(String action, VoidCallback? callback) {
+    AnalyticsService.instance.logEvent('via_action_clicked', {'action': action});
+    callback?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 16,
+      bottom: 16,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          if (_open)
+            Material(
+              elevation: 4,
+              borderRadius: BorderRadius.circular(8),
+              color: Theme.of(context).colorScheme.surface,
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Wrap(
+                  spacing: 8,
+                  children: [
+                    ActionChip(
+                      label: const Text('Explain'),
+                      onPressed: () => _handleText('Explain'),
+                    ),
+                    ActionChip(
+                      label: const Text('Simplify'),
+                      onPressed: () => _handleText('Simplify'),
+                    ),
+                    ActionChip(
+                      label: const Text('Budget'),
+                      onPressed: () => _handleText('Budget'),
+                    ),
+                    ActionChip(
+                      label: const Text('Make Plan'),
+                      onPressed: () => _handleNav('Make Plan', widget.onMakePlan),
+                    ),
+                    ActionChip(
+                      label: const Text('Visualize'),
+                      onPressed: () => _handleNav('Visualize', widget.onVisualize),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          if (_open) const SizedBox(height: 8),
+          FloatingActionButton.small(
+            onPressed: _toggle,
+            child: Icon(_open ? Icons.close : Icons.chat_bubble),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add ViaService for Cloud Function calls
- introduce ViaOverlay with action chips and telemetry
- mount Via overlay on roller, plan detail, and visualizer screens
- stub viaReply Cloud Function

## Testing
- `npm test` *(fails: Missing script "test")*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ebe6731883228d8fd421c319b727