### PR TITLE
feat(lighting): project-level profiles with Plan/Visualizer propagation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -43,6 +43,7 @@ exports.generateColorPlanV2 = functions.https.onCall(async (data, context) => {
     roomPlaybook: [
       { roomType: 'living', placements: placementMap, notes: 'Adjust accents as needed.' },
     ],
+    debugLightingProfile: ctx?.lightingProfile || null,
   };
 });
 // END REGION: CODEX-ADD color-plan-fn
@@ -172,6 +173,7 @@ exports.generateColorPlanV1 = functions.https.onCall(async (data, context) => {
     doDont,
     sampleSequence,
     roomPlaybook,
+    debugLightingProfile: ctx?.lightingProfile || null,
   };
 });
 

--- a/lib/models/lighting_profile.dart
+++ b/lib/models/lighting_profile.dart
@@ -1,0 +1,35 @@
+// lib/models/lighting_profile.dart
+import 'package:flutter/material.dart';
+
+/// Lighting profiles that influence color rendering.
+/// Defaults to [LightingProfile.mixed].
+///
+enum LightingProfile {
+  mixed,
+  warm,
+  cool,
+}
+
+/// User-facing labels for each profile.
+const Map<LightingProfile, String> lightingProfileLabels = {
+  LightingProfile.mixed: 'Mixed',
+  LightingProfile.warm: 'Warm',
+  LightingProfile.cool: 'Cool',
+};
+
+LightingProfile lightingProfileFromString(String? value) {
+  switch (value) {
+    case 'warm':
+      return LightingProfile.warm;
+    case 'cool':
+      return LightingProfile.cool;
+    case 'mixed':
+    default:
+      return LightingProfile.mixed;
+  }
+}
+
+extension LightingProfileX on LightingProfile {
+  String get label => lightingProfileLabels[this] ?? name;
+}
+

--- a/lib/screens/photo_import_sheet.dart
+++ b/lib/screens/photo_import_sheet.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../models/lighting_profile.dart';
+
+/// Simple bottom sheet for choosing a lighting profile during photo import.
+Future<LightingProfile?> showLightingProfilePicker(
+  BuildContext context, {
+  required LightingProfile current,
+}) {
+  LightingProfile temp = current;
+  return showModalBottomSheet<LightingProfile>(
+    context: context,
+    builder: (ctx) {
+      return StatefulBuilder(
+        builder: (ctx, setState) {
+          return SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Text('Lighting Profile',
+                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                ),
+                ...LightingProfile.values.map(
+                  (p) => RadioListTile<LightingProfile>(
+                    title: Text(p.label),
+                    value: p,
+                    groupValue: temp,
+                    onChanged: (v) => setState(() => temp = v ?? temp),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(temp),
+                  child: const Text('Done'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+

--- a/lib/services/color_plan_service.dart
+++ b/lib/services/color_plan_service.dart
@@ -2,7 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import '../models/color_plan.dart';
+import '../models/lighting_profile.dart';
 import 'analytics_service.dart';
+import 'lighting_service.dart';
 
 /// Service for managing color plans in Firestore and generating new ones via Cloud Functions.
 class ColorPlanService {
@@ -32,12 +34,17 @@ class ColorPlanService {
       throw Exception('Must be logged in to create a color plan');
     }
 
+    final profile = await LightingService().getProfile(projectId);
+
     final callable = _functions.httpsCallable('generateColorPlanV2');
     final resp = await callable.call({
       'projectId': projectId,
       'paletteColorIds': paletteColorIds,
       'vibe': vibe,
-      'context': context ?? {},
+      'context': {
+        'lightingProfile': profile.name,
+        ...?context,
+      },
     });
 
     final data = Map<String, dynamic>.from(resp.data as Map);

--- a/lib/services/lighting_service.dart
+++ b/lib/services/lighting_service.dart
@@ -1,0 +1,41 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/lighting_profile.dart';
+import 'analytics_service.dart';
+
+/// Service for persisting lighting profile settings per project.
+class LightingService {
+  static final LightingService _instance = LightingService._();
+  factory LightingService() => _instance;
+
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  LightingService._();
+
+  DocumentReference<Map<String, dynamic>> _settingsDoc(String projectId) =>
+      _db.collection('projects').doc(projectId).collection('meta').doc('settings');
+
+  /// Reads the lighting profile for the given project. Defaults to [LightingProfile.mixed].
+  Future<LightingProfile> getProfile(String projectId) async {
+    try {
+      final snap = await _settingsDoc(projectId).get();
+      final value = snap.data()?['lightingProfile'] as String?;
+      return lightingProfileFromString(value);
+    } catch (_) {
+      return LightingProfile.mixed;
+    }
+  }
+
+  /// Persists the lighting profile and logs telemetry.
+  Future<void> setProfile(String projectId, LightingProfile profile) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return; // fail silently if not signed in
+    await _settingsDoc(projectId)
+        .set({'lightingProfile': profile.name}, SetOptions(merge: true));
+    await AnalyticsService.instance
+        .logEvent('lighting_profile_selected', {'profile': profile.name});
+  }
+}
+

--- a/lib/services/visualizer_service.dart
+++ b/lib/services/visualizer_service.dart
@@ -75,6 +75,7 @@ class VisualizerService {
     required List<String> surfaces,
     required int variants,
     String? storyId,
+    String? lightingProfile,
   }) async {
   final callable = _firebaseFunctionsShimInstance.httpsCallable('generateFromPhoto');
     final resp = await callable.call({
@@ -83,6 +84,7 @@ class VisualizerService {
       'surfaces': surfaces,
       'variants': variants,
       'storyId': storyId,
+      if (lightingProfile != null) 'lightingProfile': lightingProfile,
     });
     return List<Map<String, dynamic>>.from(resp.data['results'] as List);
   }
@@ -91,25 +93,37 @@ class VisualizerService {
     required String roomType,
     required String style,
     required int variants,
+    String? lightingProfile,
   }) async {
   final callable = _firebaseFunctionsShimInstance.httpsCallable('generateMockup');
     final resp = await callable.call({
       'roomType': roomType,
       'style': style,
       'variants': variants,
+      if (lightingProfile != null) 'lightingProfile': lightingProfile,
     });
     return List<Map<String, dynamic>>.from(resp.data['results'] as List);
   }
 
-  Future<VisualizerJob> renderFast(String imageUrl, List<String> paletteColorIds) async {
+  Future<VisualizerJob> renderFast(String imageUrl, List<String> paletteColorIds,
+      {String? lightingProfile}) async {
     final callable = _functions.httpsCallable('renderFast');
-    final resp = await callable.call({'imageUrl': imageUrl, 'palette': paletteColorIds});
+    final resp = await callable.call({
+      'imageUrl': imageUrl,
+      'palette': paletteColorIds,
+      if (lightingProfile != null) 'lightingProfile': lightingProfile,
+    });
     return VisualizerJob.fromMap(Map<String, dynamic>.from(resp.data as Map));
   }
 
-  Future<VisualizerJob> renderHq(String imageUrl, List<String> paletteColorIds) async {
+  Future<VisualizerJob> renderHq(String imageUrl, List<String> paletteColorIds,
+      {String? lightingProfile}) async {
     final callable = _functions.httpsCallable('renderHq');
-    final resp = await callable.call({'imageUrl': imageUrl, 'palette': paletteColorIds});
+    final resp = await callable.call({
+      'imageUrl': imageUrl,
+      'palette': paletteColorIds,
+      if (lightingProfile != null) 'lightingProfile': lightingProfile,
+    });
     return VisualizerJob.fromMap(Map<String, dynamic>.from(resp.data as Map));
   }
 


### PR DESCRIPTION
## Summary
- add LightingProfile enum and service to persist selection per project
- surface lighting profile picker in photo import and visualizer quick control
- forward lightingProfile to plan generation, visualizer calls, and echo in function responses

## Testing
- `dart format lib/models/lighting_profile.dart lib/services/lighting_service.dart lib/screens/photo_import_sheet.dart lib/services/color_plan_service.dart lib/screens/visualizer_screen.dart lib/services/visualizer_service.dart functions/index.js` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm --prefix functions test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4ed6e78388322b5845ce548dd2bc4