### PR TITLE
feat(constraints): fixed-element assist + undertone filters

### DIFF
--- a/lib/models/fixed_elements.dart
+++ b/lib/models/fixed_elements.dart
@@ -1,0 +1,50 @@
+// lib/models/fixed_elements.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Represents a fixed element in a project such as flooring,
+/// countertops, or existing tile that could influence palette choices.
+class FixedElement {
+  final String id;
+  final String name;
+  final String type; // e.g., floor, counter, tile
+  final String undertone; // warm, cool, neutral
+
+  FixedElement({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.undertone,
+  });
+
+  factory FixedElement.fromSnap(DocumentSnapshot snap) {
+    final d = snap.data() as Map<String, dynamic>? ?? {};
+    return FixedElement(
+      id: snap.id,
+      name: d['name'] ?? '',
+      type: d['type'] ?? 'other',
+      undertone: d['undertone'] ?? 'neutral',
+    );
+  }
+
+  factory FixedElement.fromJson(String id, Map<String, dynamic> json) =>
+      FixedElement(
+        id: id,
+        name: json['name'] ?? '',
+        type: json['type'] ?? 'other',
+        undertone: json['undertone'] ?? 'neutral',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'type': type,
+        'undertone': undertone,
+      };
+
+  FixedElement copyWith({String? name, String? type, String? undertone}) =>
+      FixedElement(
+        id: id,
+        name: name ?? this.name,
+        type: type ?? this.type,
+        undertone: undertone ?? this.undertone,
+      );
+}

--- a/lib/services/fixed_element_service.dart
+++ b/lib/services/fixed_element_service.dart
@@ -1,0 +1,59 @@
+// lib/services/fixed_element_service.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/fixed_elements.dart';
+import 'analytics_service.dart';
+
+/// Service to manage fixed elements for a project.
+class FixedElementService {
+  FixedElementService._();
+  static final FixedElementService _instance = FixedElementService._();
+  factory FixedElementService() => _instance;
+
+  final _db = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
+
+  CollectionReference<Map<String, dynamic>> _col(String uid, String projectId) =>
+      _db
+          .collection('users')
+          .doc(uid)
+          .collection('projects')
+          .doc(projectId)
+          .collection('fixedElements');
+
+  Future<List<FixedElement>> listElements(String projectId) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return [];
+    final snap = await _col(uid, projectId).get();
+    return snap.docs.map((d) => FixedElement.fromSnap(d)).toList();
+  }
+
+  Future<void> saveAll(String projectId, List<FixedElement> elements) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+    final col = _col(uid, projectId);
+    final batch = _db.batch();
+
+    final existing = await col.get();
+    for (final doc in existing.docs) {
+      if (!elements.any((e) => e.id == doc.id)) {
+        batch.delete(doc.reference);
+      }
+    }
+    for (final e in elements) {
+      batch.set(col.doc(e.id), e.toJson());
+    }
+    await batch.commit();
+    await AnalyticsService().logEvent('fixed_elements_saved', {
+      'project_id': projectId,
+      'count': elements.length,
+    });
+  }
+
+  Future<void> deleteElement(String projectId, String id) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+    await _col(uid, projectId).doc(id).delete();
+  }
+}

--- a/lib/utils/color_utils.dart
+++ b/lib/utils/color_utils.dart
@@ -234,22 +234,29 @@ class ColorUtils {
   }
 
   // Get color temperature description
-  static String getColorTemperature(Color color) {
-    final rgb = [((color.r * 255.0).round() & 0xff), ((color.g * 255.0).round() & 0xff), ((color.b * 255.0).round() & 0xff)];
-    final r = rgb[0];
-    final g = rgb[1];
-    final b = rgb[2];
+    static String getColorTemperature(Color color) {
+      final rgb = [((color.r * 255.0).round() & 0xff), ((color.g * 255.0).round() & 0xff), ((color.b * 255.0).round() & 0xff)];
+      final r = rgb[0];
+      final g = rgb[1];
+      final b = rgb[2];
 
     // Simple temperature analysis
-    if ((r + g) > (b * 1.3)) {
-      return 'Warm';
-    } else if ((g + b) > (r * 1.3)) {
-      return 'Cool';
-    } else {
-      return 'Neutral';
+      if ((r + g) > (b * 1.3)) {
+        return 'Warm';
+      } else if ((g + b) > (r * 1.3)) {
+        return 'Cool';
+      } else {
+        return 'Neutral';
+      }
+    }
+
+    /// Placeholder for future image-based undertone inference.
+    /// Currently unimplemented and always returns `null`.
+    static Future<String?> inferUndertoneFromImage(dynamic image) async {
+      // TODO: Implement real undertone analysis from an image.
+      return null;
     }
   }
-}
 
 // LRV helper function for paint data
 double lrvForPaint({double? paintLrv, required String hex}) {

--- a/lib/utils/palette_isolate.dart
+++ b/lib/utils/palette_isolate.dart
@@ -8,6 +8,7 @@ class _RollArgs {
   final int modeIndex;
   final bool diversify;
   final List<List<double>>? slotLrvHints;
+  final List<String>? fixedUndertones;
 
   _RollArgs({
     required this.available,
@@ -15,6 +16,7 @@ class _RollArgs {
     required this.modeIndex,
     required this.diversify,
     this.slotLrvHints,
+    this.fixedUndertones,
   });
 
   Map<String, dynamic> toMap() => {
@@ -23,6 +25,7 @@ class _RollArgs {
         'modeIndex': modeIndex,
         'diversify': diversify,
         'slotLrvHints': slotLrvHints,
+        'fixedUndertones': fixedUndertones,
       };
 
   static _RollArgs fromMap(Map<String, dynamic> m) => _RollArgs(
@@ -33,6 +36,9 @@ class _RollArgs {
         slotLrvHints: m['slotLrvHints'] != null
             ? List<List<double>>.from(
                 (m['slotLrvHints'] as List).map((e) => List<double>.from(e)))
+            : null,
+        fixedUndertones: m['fixedUndertones'] != null
+            ? List<String>.from(m['fixedUndertones'] as List)
             : null,
       );
 }
@@ -56,6 +62,7 @@ List<Map<String, dynamic>> rollPaletteInIsolate(Map<String, dynamic> raw) {
     mode: HarmonyMode.values[args.modeIndex],
     diversifyBrands: args.diversify,
     slotLrvHints: args.slotLrvHints,
+    fixedUndertones: args.fixedUndertones,
   );
 
   // Send back serializable maps (we'll map to Paint on the main isolate)

--- a/lib/widgets/fixed_elements_sheet.dart
+++ b/lib/widgets/fixed_elements_sheet.dart
@@ -1,0 +1,131 @@
+// lib/widgets/fixed_elements_sheet.dart
+import 'package:flutter/material.dart';
+import '../models/fixed_elements.dart';
+import '../services/fixed_element_service.dart';
+
+/// Bottom sheet for managing fixed elements in a project.
+class FixedElementsSheet extends StatefulWidget {
+  final String projectId;
+  final List<FixedElement> elements;
+  const FixedElementsSheet({super.key, required this.projectId, required this.elements});
+
+  @override
+  State<FixedElementsSheet> createState() => _FixedElementsSheetState();
+}
+
+class _FixedElementsSheetState extends State<FixedElementsSheet> {
+  late List<FixedElement> _elements;
+
+  static const _undertones = ['warm', 'cool', 'neutral'];
+  static const _types = ['floor', 'counter', 'tile', 'other'];
+
+  @override
+  void initState() {
+    super.initState();
+    _elements = widget.elements.map((e) => e).toList();
+  }
+
+  void _addElement() {
+    setState(() {
+      _elements.add(FixedElement(
+          id: UniqueKey().toString(),
+          name: '',
+          type: 'other',
+          undertone: 'neutral'));
+    });
+  }
+
+  Future<void> _save() async {
+    await FixedElementService().saveAll(widget.projectId, _elements);
+    Navigator.of(context).pop(_elements);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Fixed Elements', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              IconButton(onPressed: () => Navigator.of(context).pop(), icon: const Icon(Icons.close)),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _elements.length,
+              itemBuilder: (context, i) {
+                final e = _elements[i];
+                return Card(
+                  margin: const EdgeInsets.symmetric(vertical: 4),
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        TextField(
+                          decoration: const InputDecoration(labelText: 'Name'),
+                          controller: TextEditingController(text: e.name),
+                          onChanged: (v) => _elements[i] = e.copyWith(name: v),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: DropdownButton<String>(
+                                value: e.type,
+                                isExpanded: true,
+                                items: _types
+                                    .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                                    .toList(),
+                                onChanged: (v) => setState(() => _elements[i] = e.copyWith(type: v)),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: DropdownButton<String>(
+                                value: e.undertone,
+                                isExpanded: true,
+                                items: _undertones
+                                    .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                                    .toList(),
+                                onChanged: (v) => setState(() => _elements[i] = e.copyWith(undertone: v)),
+                              ),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete_outline),
+                              onPressed: () => setState(() => _elements.removeAt(i)),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              TextButton.icon(
+                onPressed: _addElement,
+                icon: const Icon(Icons.add),
+                label: const Text('Add'),
+              ),
+              const Spacer(),
+              FilledButton(
+                onPressed: _save,
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add FixedElement model, service, and editing sheet
- bias palette generation against fixed element undertones and log telemetry
- plumb fixed elements through roller and plan service, plus undertone inference stub

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f046f5cc83229ce519ac330cf574