### PR TITLE
feat: adaptive landing and onboarding with permissions microcopy

### DIFF
--- a/lib/screens/create_screen.dart
+++ b/lib/screens/create_screen.dart
@@ -2,10 +2,40 @@ import 'package:flutter/material.dart';
 import 'color_plan_screen.dart';
 import 'roller_screen.dart';
 import 'visualizer_screen.dart';
+// REGION: CODEX-ADD onboarding-imports
+import '../services/user_prefs_service.dart';
+import 'onboarding_screen.dart';
+// END REGION: CODEX-ADD onboarding-imports
 
 /// Entry hub for starting new workflows.
-class CreateScreen extends StatelessWidget {
+class CreateScreen extends StatefulWidget {
   const CreateScreen({super.key});
+
+  @override
+  State<CreateScreen> createState() => _CreateScreenState();
+}
+
+class _CreateScreenState extends State<CreateScreen> {
+  @override
+  void initState() {
+    super.initState();
+    _checkOnboarding();
+  }
+
+  Future<void> _checkOnboarding() async {
+    // REGION: CODEX-ADD onboarding-gate
+    final prefs = await UserPrefsService.fetch();
+    if (!prefs.firstRunCompleted && mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          fullscreenDialog: true,
+          builder: (_) => const OnboardingScreen(),
+        ),
+      );
+    }
+    // END REGION: CODEX-ADD onboarding-gate
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -47,9 +47,7 @@ class HomeScreenState extends State<HomeScreen> {
   Future<void> _determineLanding() async {
     // REGION: CODEX-ADD adaptive-landing
     final prefs = await UserPrefsService.fetch();
-    if (prefs.firstRunCompleted) {
-      setState(() => _currentIndex = 1);
-    }
+    setState(() => _currentIndex = prefs.firstRunCompleted ? 1 : 0);
     // END REGION: CODEX-ADD adaptive-landing
   }
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../services/user_prefs_service.dart';
+import '../services/analytics_service.dart';
+
+/// Simple 3-page onboarding carousel shown on first run.
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final PageController _controller = PageController();
+  int _index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _controller,
+                onPageChanged: (i) => setState(() => _index = i),
+                children: const [
+                  _OnboardPage(
+                    title: 'Welcome to Color Canvas',
+                    text:
+                        'Discover paint palettes and visualize them in your space.',
+                  ),
+                  _OnboardPage(
+                    title: 'Create First',
+                    text: 'Start by designing palettes then plan and visualize.',
+                  ),
+                  _OnboardPage(
+                    title: 'Your Privacy',
+                    text:
+                        'We only access your camera or photos with your permission.',
+                  ),
+                ],
+              ),
+            ),
+            if (_index == 2)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: ElevatedButton(
+                  onPressed: _complete,
+                  child: const Text('Get Started'),
+                ),
+              )
+            else
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    3,
+                    (i) => Container(
+                      width: 8,
+                      height: 8,
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: _index == i
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.grey,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _complete() async {
+    await UserPrefsService.markFirstRunCompleted();
+    await AnalyticsService.instance.onboardingCompleted();
+    if (mounted) Navigator.pop(context);
+  }
+}
+
+class _OnboardPage extends StatelessWidget {
+  final String title;
+  final String text;
+  const _OnboardPage({required this.title, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.headlineMedium),
+          const SizedBox(height: 16),
+          Text(text, textAlign: TextAlign.center),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/story_studio_screen.dart
+++ b/lib/screens/story_studio_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart' hide Paint;
 import 'package:image_picker/image_picker.dart';
+// REGION: CODEX-ADD permissions-import
+import '../services/permissions_service.dart';
+import 'package:permission_handler/permission_handler.dart';
+// END REGION: CODEX-ADD permissions-import
 import 'dart:io';
 import 'dart:math' as math;
 import 'package:color_canvas/utils/slug_utils.dart';
@@ -199,6 +203,11 @@ class _StoryStudioScreenState extends State<StoryStudioScreen> {
   Future<void> _pickImage() async {
     final ImagePicker picker = ImagePicker();
     try {
+      final granted = await PermissionsService.confirmAndRequest(
+        context,
+        Permission.photos,
+      );
+      if (!granted) return;
       final XFile? image = await picker.pickImage(
         source: ImageSource.gallery,
         maxWidth: 1200,

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -23,6 +23,10 @@ import 'photo_import_sheet.dart';
 // REGION: CODEX-ADD user-prefs-import
 import '../services/user_prefs_service.dart';
 // END REGION: CODEX-ADD user-prefs-import
+// REGION: CODEX-ADD permissions-import
+import '../services/permissions_service.dart';
+import 'package:permission_handler/permission_handler.dart';
+// END REGION: CODEX-ADD permissions-import
 
 enum CompareMode { none, grid, split, slider }
 
@@ -131,6 +135,11 @@ class _VisualizerScreenState extends State<VisualizerScreen>
 
   // ─────────────────────────── Actions
   Future<void> _pickImage() async {
+    final granted = await PermissionsService.confirmAndRequest(
+      context,
+      Permission.photos,
+    );
+    if (!granted) return;
     final file =
         await _picker.pickImage(source: ImageSource.gallery, imageQuality: 95);
     if (file == null) return;

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -719,6 +719,20 @@ class AnalyticsService {
     });
   }
   // END REGION: CODEX-ADD resume-last analytics
+
+  // REGION: CODEX-ADD onboarding-permissions analytics
+  Future<void> onboardingCompleted() async {
+    await _logEvent('onboarding_completed', {});
+  }
+
+  Future<void> permissionMicrocopyShown(String type) async {
+    await _logEvent('permission_microcopy_shown', {'type': type});
+  }
+
+  Future<void> permissionRequested(String type) async {
+    await _logEvent('permission_requested', {'type': type});
+  }
+  // END REGION: CODEX-ADD onboarding-permissions analytics
 }
 
 // Extension methods for easy access

--- a/lib/services/permissions_service.dart
+++ b/lib/services/permissions_service.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'analytics_service.dart';
+
+/// Lightweight wrapper to show permission microcopy before requesting access.
+class PermissionsService {
+  static Future<bool> confirmAndRequest(
+      BuildContext context, Permission permission) async {
+    final type = permission == Permission.camera ? 'camera' : 'photos';
+    final titles = {
+      'camera': 'Camera Access',
+      'photos': 'Photo Access',
+    };
+    final messages = {
+      'camera':
+          'We use your camera only to capture photos of your space. No media leaves your device without your consent.',
+      'photos':
+          'We need access to your photo library to visualize your room. Images stay private unless you choose to share.',
+    };
+    // Show microcopy dialog
+    AnalyticsService.instance.permissionMicrocopyShown(type);
+    final proceed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(titles[type]!),
+        content: Text(messages[type]!),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Not now')),
+          TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Continue')),
+        ],
+      ),
+    );
+    if (proceed != true) return false;
+    // Request permission
+    AnalyticsService.instance.permissionRequested(type);
+    final status = await permission.request();
+    return status.isGranted;
+  }
+}

--- a/lib/services/user_prefs_service.dart
+++ b/lib/services/user_prefs_service.dart
@@ -52,5 +52,13 @@ class UserPrefsService {
       }, SetOptions(merge: true));
     }
   }
+
+  /// Mark onboarding as completed without updating project info.
+  static Future<void> markFirstRunCompleted() async {
+    final doc = _doc;
+    if (doc != null) {
+      await doc.set({'firstRunCompleted': true}, SetOptions(merge: true));
+    }
+  }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   printing: ^5.12.0
   screenshot: ^3.0.0
   image_picker: '>=1.1.2'
+  permission_handler: ^11.3.0
   http: ^1.1.0
   # UI helpers
   photo_view: ^0.15.0


### PR DESCRIPTION
## Summary
- route returning users to Projects based on stored prefs
- add onboarding carousel and gate Create tab on first run
- show microcopy before camera or gallery access

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format lib/services/permissions_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fdfc49188322938d168adfe008f6