### PR TITLE
feat: a11y polish and house flow checks

### DIFF
--- a/lib/models/house_flow.dart
+++ b/lib/models/house_flow.dart
@@ -1,0 +1,29 @@
+class FlowEdge {
+  final String from;
+  final String to;
+  const FlowEdge({required this.from, required this.to});
+
+  factory FlowEdge.fromJson(Map<String, dynamic> j) =>
+      FlowEdge(from: j['from'] as String, to: j['to'] as String);
+
+  Map<String, dynamic> toJson() => {'from': from, 'to': to};
+}
+
+class HouseFlow {
+  final List<String> rooms;
+  final List<FlowEdge> edges;
+  const HouseFlow({required this.rooms, required this.edges});
+
+  factory HouseFlow.fromJson(Map<String, dynamic> j) => HouseFlow(
+        rooms: (j['rooms'] as List<dynamic>? ?? []).cast<String>(),
+        edges: (j['edges'] as List<dynamic>? ?? [])
+            .map((e) => FlowEdge.fromJson(Map<String, dynamic>.from(e)))
+            .toList(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'rooms': rooms,
+        'edges': edges.map((e) => e.toJson()).toList(),
+      };
+}
+

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -28,6 +28,7 @@ import '../services/user_prefs_service.dart';
 import '../services/permissions_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 // END REGION: CODEX-ADD permissions-import
+import '../services/accessibility_service.dart';
 
 enum CompareMode { none, grid, split, slider }
 
@@ -95,6 +96,10 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   @override
   void initState() {
     super.initState();
+
+    AccessibilityService.instance
+        .addListener(() => mounted ? setState(() {}) : null);
+    AccessibilityService.instance.load();
     
     // Track visualizer screen view
     AnalyticsService.instance.screenView('visualizer');
@@ -351,6 +356,10 @@ class _VisualizerScreenState extends State<VisualizerScreen>
             left: 12,
             child: IconButton(
               icon: Icon(_showMaskTools ? Icons.close : Icons.brush),
+              tooltip:
+                  _showMaskTools ? 'Close mask tools' : 'Open mask tools',
+              constraints:
+                  const BoxConstraints(minWidth: 44, minHeight: 44),
               onPressed: () =>
                   setState(() => _showMaskTools = !_showMaskTools),
             ),
@@ -508,7 +517,9 @@ class _VisualizerScreenState extends State<VisualizerScreen>
     final hasResults = _results.isNotEmpty;
 
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 280),
+      duration: Duration(
+          milliseconds:
+              AccessibilityService.instance.reduceMotion ? 0 : 280),
       child: hasResults
           ? _buildResults()
           : _buildSourcePreview(theme),
@@ -529,6 +540,8 @@ class _VisualizerScreenState extends State<VisualizerScreen>
         children: [
           IconButton(
             icon: Icon(_eraseMode ? Icons.crop_square : Icons.brush),
+            tooltip: _eraseMode ? 'Draw mask' : 'Erase mask',
+            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
             onPressed: () => setState(() => _eraseMode = !_eraseMode),
           ),
           Slider(
@@ -540,6 +553,8 @@ class _VisualizerScreenState extends State<VisualizerScreen>
           ),
           IconButton(
             icon: const Icon(Icons.undo),
+            tooltip: 'Undo mask',
+            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
             onPressed: _undoStack.isEmpty
                 ? null
                 : () {
@@ -552,6 +567,8 @@ class _VisualizerScreenState extends State<VisualizerScreen>
           ),
           IconButton(
             icon: const Icon(Icons.redo),
+            tooltip: 'Redo mask',
+            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
             onPressed: _redoStack.isEmpty
                 ? null
                 : () {
@@ -564,6 +581,8 @@ class _VisualizerScreenState extends State<VisualizerScreen>
           ),
           IconButton(
             icon: const Icon(Icons.auto_fix_high),
+            tooltip: 'Mask assist',
+            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
             onPressed: _onMaskAssist,
           ),
         ],
@@ -772,7 +791,9 @@ class _ControlDock extends StatelessWidget {
             ),
             const Spacer(),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: 200),
+              duration: Duration(
+                  milliseconds:
+                      AccessibilityService.instance.reduceMotion ? 0 : 200),
               child: mode == 'photo'
                   ? TextButton.icon(
                       key: const ValueKey('upload_button'),
@@ -798,7 +819,9 @@ class _ControlDock extends StatelessWidget {
               onChanged: (v) => onRoomTypeChanged(v!),
             ),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: 200),
+              duration: Duration(
+                  milliseconds:
+                      AccessibilityService.instance.reduceMotion ? 0 : 200),
               child: onStyleChanged != null
                   ? _Dropdown(
                       key: const ValueKey('style_dropdown'),
@@ -919,7 +942,10 @@ class _Segmented extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 2),
               child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
+                duration: Duration(
+                    milliseconds: AccessibilityService.instance.reduceMotion
+                        ? 0
+                        : 200),
                 child: ChoiceChip(
                   label: Text(options[i]),
                   selected: i == selectedIndex,
@@ -1322,7 +1348,11 @@ class _VariantToolbarState extends State<VariantToolbar> {
                     final hex = r['hex'] ?? '#000000';
                     final chosen = (i == widget.selectedA) || (i == widget.selectedB);
                     return AnimatedContainer(
-                      duration: const Duration(milliseconds: 200),
+                      duration: Duration(
+                          milliseconds:
+                              AccessibilityService.instance.reduceMotion
+                                  ? 0
+                                  : 200),
                       child: GestureDetector(
                         onTap: () => widget.onSelectA(i),
                         onLongPress: () => widget.onSelectB(i),

--- a/lib/services/color_metrics_service.dart
+++ b/lib/services/color_metrics_service.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ColorMetricsService {
+  final _db = FirebaseFirestore.instance;
+
+  Future<double?> lrvOf(String colorId) async {
+    final doc = await _db.collection('paints').doc(colorId).get();
+    final data = doc.data();
+    final lab = (data?['lab'] as List?)?.cast<num>();
+    return lab != null && lab.isNotEmpty ? lab[0].toDouble() : null;
+  }
+
+  Future<double> deltaLrv(String a, String b) async {
+    final l1 = await lrvOf(a) ?? 0;
+    final l2 = await lrvOf(b) ?? 0;
+    return (l1 - l2).abs();
+  }
+
+  Future<bool> undertoneConflict(String a, String b) async {
+    final docA = await _db.collection('paints').doc(a).get();
+    final docB = await _db.collection('paints').doc(b).get();
+    final labA = (docA.data()?['lab'] as List?)?.cast<num>().toList();
+    final labB = (docB.data()?['lab'] as List?)?.cast<num>().toList();
+    if (labA == null || labB == null) return false;
+    final conflictA = (labA[1] * labB[1]) < 0 && (labA[1] - labB[1]).abs() > 20;
+    final conflictB = (labA[2] * labB[2]) < 0 && (labA[2] - labB[2]).abs() > 20;
+    return conflictA || conflictB;
+  }
+}
+

--- a/lib/services/house_flow_service.dart
+++ b/lib/services/house_flow_service.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/house_flow.dart';
+
+class HouseFlowService {
+  final _db = FirebaseFirestore.instance;
+
+  Future<HouseFlow?> getFlow(String projectId) async {
+    final doc = await _db
+        .collection('projects')
+        .doc(projectId)
+        .collection('meta')
+        .doc('houseFlow')
+        .get();
+    final data = doc.data();
+    if (data == null) return null;
+    return HouseFlow.fromJson(data);
+  }
+
+  Future<void> setFlow(String projectId, HouseFlow flow) async {
+    await _db
+        .collection('projects')
+        .doc(projectId)
+        .collection('meta')
+        .doc('houseFlow')
+        .set(flow.toJson());
+  }
+}
+

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -152,6 +152,11 @@ ThemeData get lightTheme => ThemeData(
           fontWeight: FontWeight.normal,
         ),
       ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: LightModeColors.lightPrimary,
+        ),
+      ),
     );
 
 ThemeData get darkTheme => ThemeData(
@@ -245,6 +250,11 @@ ThemeData get darkTheme => ThemeData(
         bodySmall: GoogleFonts.inter(
           fontSize: FontSizes.bodySmall,
           fontWeight: FontWeight.normal,
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: DarkModeColors.darkPrimary,
         ),
       ),
     );

--- a/lib/utils/palette_transforms.dart
+++ b/lib/utils/palette_transforms.dart
@@ -113,3 +113,23 @@ List<ColorId> cooler(
       })
       .toList(growable: false);
 }
+
+/// Generate a color-blind-friendly variant by increasing luminance contrast
+/// and reducing red/green components.
+List<ColorId> cbFriendlyVariant(
+  List<ColorId> ids,
+  LabLookup labOf,
+  NearestId nearestId,
+) {
+  return ids
+      .map((id) {
+        final lab = labOf(id);
+        final l = lab.l < 50.0
+            ? math.min(100.0, lab.l + 15.0)
+            : math.max(0.0, lab.l - 15.0);
+        final adjusted = Lab(l, lab.a * 0.5, lab.b);
+        final nearest = nearestId(adjusted);
+        return nearest ?? id;
+      })
+      .toList(growable: false);
+}


### PR DESCRIPTION
## Summary
- add reduce motion and color-blind friendly settings with persisted accessibility service
- wire up semantics, larger hit targets, and cb-safe palette option
- compute house flow adjacency warnings in plan detail

## Testing
- `flutter format lib/services/accessibility_service.dart lib/screens/settings_screen.dart lib/screens/roller_screen.dart lib/screens/visualizer_screen.dart lib/theme.dart lib/utils/palette_transforms.dart lib/screens/color_plan_detail_screen.dart lib/models/house_flow.dart lib/services/color_metrics_service.dart lib/services/house_flow_service.dart` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b5029cbdc88322a79107e544789f04