### PR TITLE
feat(share): deep links + shareable palette/plan/viz links with OG fallback

### DIFF
--- a/lib/screens/color_plan_detail_screen.dart
+++ b/lib/screens/color_plan_detail_screen.dart
@@ -16,6 +16,7 @@ import '../services/network_utils.dart';
 import '../services/ambient_audio_controller.dart';
 import '../services/accessibility_service.dart';
 import '../services/analytics_service.dart';
+import '../services/deep_link_service.dart';
 import '../services/painter_pack_service.dart';
 import '../widgets/usage_guide_card.dart';
 import '../widgets/motion_aware_parallax.dart';
@@ -1999,6 +2000,11 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
   /// Share the color story
   Future<void> _shareStory(ColorStory story) async {
     try {
+      if (widget.projectId != null) {
+        final ok = await DeepLinkService.instance
+            .ensureProjectShareable(context, widget.projectId!);
+        if (!ok) return;
+      }
       String excerpt = '';
       String contextInfo = '';
       String colors = '';
@@ -2041,8 +2047,16 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
         contextInfo =
             '\n\n${story.style.toUpperCase()} ${story.room.toUpperCase()}';
       }
+      Uri? link;
+      if (widget.projectId != null) {
+        link = await DeepLinkService.instance.createLink(
+          'plan',
+          story.id,
+          params: {'projectId': widget.projectId!},
+        );
+      }
       final shareText =
-          '$shareTitle$contextInfo\n\n$excerpt\n\n🎨 View this color story: https://colorcanvas.app/story/${story.id}';
+          '$shareTitle$contextInfo\n\n$excerpt\n\n🎨 View this color story: ${link ?? ''}';
 
       // Share the story
       await SharePlus.instance.share(

--- a/lib/screens/roller_screen.dart
+++ b/lib/screens/roller_screen.dart
@@ -30,6 +30,8 @@ import 'package:color_canvas/widgets/fixed_elements_sheet.dart';
 import 'package:color_canvas/models/fixed_elements.dart';
 import 'package:color_canvas/services/accessibility_service.dart';
 import 'package:color_canvas/services/fixed_element_service.dart';
+import 'package:share_plus/share_plus.dart';
+import '../services/deep_link_service.dart';
 import '../services/feature_flags.dart';
 
 // Custom intents for keyboard navigation
@@ -1177,10 +1179,20 @@ class _RollerScreenState extends RollerScreenStatePublic {
     );
   }
   
-  void _shareCurrentPalette() {
-    // Minimal placeholder to clear analyzer warning; hook up Share later
-    final names = _currentPalette.map((p) => p.name).join(', ');
-    debugPrint('Share palette: [$names]');
+  Future<void> _shareCurrentPalette() async {
+    if (widget.projectId == null) return;
+    final ok = await DeepLinkService.instance
+        .ensureProjectShareable(context, widget.projectId!);
+    if (!ok) return;
+    final ids = _currentPalette.map((p) => p.id).toList();
+    final uri = await DeepLinkService.instance.createLink(
+      'palette',
+      widget.projectId!,
+      params: {'colors': ids.join(',')},
+    );
+    await SharePlus.instance.share(
+      ShareParams(text: uri.toString()),
+    );
   }
 
   // REGION: CODEX-ADD core-loop-cta-row

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -32,6 +32,8 @@ import '../services/permissions_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 // END REGION: CODEX-ADD permissions-import
 import '../services/accessibility_service.dart';
+import 'package:share_plus/share_plus.dart';
+import '../services/deep_link_service.dart';
 
 enum CompareMode { none, grid, split, slider }
 
@@ -209,6 +211,19 @@ class _VisualizerScreenState extends State<VisualizerScreen>
         _results = [];
       });
     }
+  }
+
+  Future<void> _shareVisualization() async {
+    if (widget.projectId == null) return;
+    final ok = await DeepLinkService.instance
+        .ensureProjectShareable(context, widget.projectId!);
+    if (!ok) return;
+    final uri = await DeepLinkService.instance.createLink(
+      'viz',
+      widget.jobId ?? 'latest',
+      params: {'projectId': widget.projectId!},
+    );
+    await SharePlus.instance.share(ShareParams(text: uri.toString()));
   }
 
   void _switchPalette(int index) {
@@ -396,6 +411,12 @@ class _VisualizerScreenState extends State<VisualizerScreen>
         title: const Text('AI Visualizer'),
         centerTitle: true,
         elevation: 0,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.ios_share_outlined),
+            onPressed: _shareVisualization,
+          ),
+        ],
         flexibleSpace: Container(
           decoration: const BoxDecoration(
             gradient: LinearGradient(

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -1,0 +1,110 @@
+// lib/services/deep_link_service.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../main.dart';
+import 'analytics_service.dart';
+
+/// Handles creation and routing of shareable deep links.
+class DeepLinkService {
+  DeepLinkService._() {
+    _initDynamicLinks();
+  }
+
+  static final DeepLinkService instance = DeepLinkService._();
+
+  final _dynamicLinks = FirebaseDynamicLinks.instance;
+
+  Future<Uri> createLink(String type, String id,
+      {Map<String, String>? params}) async {
+    final uri = Uri.https('colorcanvas.app', '/$type/$id', params);
+    final link = DynamicLinkParameters(
+      link: uri,
+      uriPrefix: 'https://colorcanvas.page.link',
+      androidParameters:
+          const AndroidParameters(packageName: 'app.colorcanvas', minimumVersion: 0),
+      iosParameters:
+          const IOSParameters(bundleId: 'app.colorcanvas', minimumVersion: '0'),
+    );
+    final shortLink = await _dynamicLinks.buildShortLink(link);
+    AnalyticsService.instance
+        .logEvent('share_link_created', {'type': type});
+    return shortLink.shortUrl;
+  }
+
+  Future<bool> ensureProjectShareable(
+      BuildContext context, String projectId) async {
+    final doc = await FirebaseFirestore.instance
+        .collection('projects')
+        .doc(projectId)
+        .get();
+    final shareable = (doc.data()?['shareable'] as bool?) ?? false;
+    if (shareable) return true;
+
+    final enable = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Enable Sharing?'),
+        content: const Text(
+            'This project is private. Enable sharing to generate a link?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    );
+
+    if (enable == true) {
+      await doc.reference.update({'shareable': true});
+      return true;
+    }
+    return false;
+  }
+
+  void _initDynamicLinks() {
+    _dynamicLinks.onLink.listen((data) {
+      _handleLink(data.link);
+    });
+    _dynamicLinks.getInitialLink().then((data) {
+      final link = data?.link;
+      if (link != null) {
+        _handleLink(link);
+      }
+    });
+  }
+
+  void _handleLink(Uri link) {
+    final segments = link.pathSegments;
+    if (segments.isEmpty) return;
+    final type = segments.first;
+    final id = segments.length > 1 ? segments[1] : null;
+    final navigator = MyApp.navigatorKey.currentState;
+    switch (type) {
+      case 'palette':
+        navigator?.pushNamed('/roller', arguments: {
+          'seedPaletteId': id,
+        });
+        break;
+      case 'plan':
+        if (id != null) {
+          navigator?.pushNamed('/colorPlanDetail', arguments: id);
+        }
+        break;
+      case 'viz':
+        navigator?.pushNamed('/visualizer', arguments: {
+          'jobId': id,
+        });
+        break;
+    }
+    AnalyticsService.instance
+        .logEvent('share_link_opened', {'type': type});
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   sqflite: ^2.4.2
   url_launcher: ^6.3.0
   firebase_remote_config: ^6.0.0
+  firebase_dynamic_links: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,9 @@
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
+  <meta property="og:title" content="ColorCanvas Palette">
+  <meta property="og:description" content="Shared palette preview">
+  <meta property="og:image" content="icons/Icon-192.png">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- Generate share links with Firebase Dynamic Links via new DeepLinkService and wire up routing
- Gate sharing behind project shareable flag and expose share actions on palette, plan, and visualizer screens
- Provide basic Open Graph metadata for web link previews

## Testing
- `dart format lib/services/deep_link_service.dart lib/screens/roller_screen.dart lib/screens/color_plan_detail_screen.dart lib/screens/visualizer_screen.dart` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b51185493883228c6530bb0950d662