### PR TITLE
journey: robust load/save, nextBestStep, funnelStage

### DIFF
--- a/lib/screens/create_screen.dart
+++ b/lib/screens/create_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:color_canvas/services/journey/journey_service.dart';
+import 'package:color_canvas/services/journey/default_color_story_v1.dart';
 import 'package:color_canvas/widgets/journey_timeline.dart';
 
 import 'interview_screen.dart';
@@ -44,7 +45,7 @@ class _CreateHubScreenState extends State<CreateHubScreen> with TickerProviderSt
       // If journey fails, initialize a safe default state
       final first = _journey.firstStep;
       _journey.state.value = JourneyState(
-        journeyId: 'default_color_story_v1',
+        journeyId: defaultColorStoryJourneyId,
         projectId: null,
         currentStepId: first.id,
         completedStepIds: const [],


### PR DESCRIPTION
## Summary
- add resilient project journey loading with offline fallback and safe writes
- surface next-best step and maintain funnel stage mapping
- bootstrap CreateHub with default journey on errors

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7426c58348322afa9e5534e81fe9f