### PR TITLE
journey: palette save + contrast review steps

### DIFF
--- a/lib/screens/create_screen.dart
+++ b/lib/screens/create_screen.dart
@@ -11,6 +11,7 @@ import 'interview_screen.dart';
 import 'roller_screen.dart';
 import 'visualizer_screen.dart';
 import 'learn_screen.dart';
+import 'review_contrast_screen.dart';
 
 /// ✨ Create Hub — Guided (orchestrated) + Tools tabs
 class CreateHubScreen extends StatefulWidget {
@@ -180,6 +181,9 @@ class _CreateHubScreenState extends State<CreateHubScreen> with TickerProviderSt
         break;
       case 'roller.build':
         _open(context, const RollerScreen());
+        break;
+      case 'review.contrast':
+        _open(context, const ReviewContrastScreen());
         break;
       case 'visualizer.photo':
       case 'visualizer.generate':

--- a/lib/screens/review_contrast_screen.dart
+++ b/lib/screens/review_contrast_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:color_canvas/services/journey/journey_service.dart';
+
+class ReviewContrastScreen extends StatelessWidget {
+  const ReviewContrastScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final journey = JourneyService.instance;
+    final colors = (journey.state.value?.artifacts['palettePreview'] as List?)
+            ?.cast<String>() ??
+        const <String>[];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Contrast Review')),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView(
+              children: colors.isNotEmpty
+                  ? colors.map((h) => _SwatchRow(hex: h)).toList()
+                  : const [
+                      Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Text('No palette loaded'),
+                      ),
+                    ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: FilledButton(
+              onPressed: () async {
+                await journey.setArtifact(
+                    'contrastReport', {'checked': true});
+                await journey.completeCurrentStep();
+                if (context.mounted) {
+                  Navigator.of(context).maybePop();
+                }
+              },
+              child: const Text('Next'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SwatchRow extends StatelessWidget {
+  final String hex;
+  const _SwatchRow({required this.hex});
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        Color(int.parse(hex.replaceAll('#', ''), radix: 16) | 0xFF000000);
+    return ListTile(
+      leading: Container(width: 40, height: 40, color: color),
+      title: Text('Sample text', style: TextStyle(color: _contrast(color))),
+    );
+  }
+
+  Color _contrast(Color c) =>
+      c.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+}

--- a/test/interview_screen_test.dart
+++ b/test/interview_screen_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:color_canvas/screens/interview_screen.dart';
+import 'package:color_canvas/services/journey/journey_service.dart';
+import 'package:color_canvas/services/journey/default_color_story_v1.dart';
+import 'package:color_canvas/services/journey/journey_models.dart';
+
+void main() {
+  testWidgets('finishing interview saves answers and advances', (tester) async {
+    final j = JourneyService.instance;
+    j.state.value = JourneyState(
+      journeyId: defaultColorStoryJourneyId,
+      projectId: null,
+      currentStepId: 'interview.basic',
+      completedStepIds: const [],
+      artifacts: const {},
+    );
+
+    await tester.pumpWidget(const MaterialApp(home: InterviewScreen()));
+
+    for (var i = 0; i < 5; i++) {
+      await tester.tap(find.text(i == 4 ? 'Finish' : 'Next'));
+      await tester.pumpAndSettle();
+    }
+
+    final state = j.state.value!;
+    expect(state.artifacts['answers'], isNotNull);
+    expect(state.completedStepIds.contains('interview.basic'), isTrue);
+    expect(state.currentStepId, 'roller.build');
+  });
+}

--- a/test/save_palette_panel_test.dart
+++ b/test/save_palette_panel_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:color_canvas/widgets/save_palette_panel.dart';
+import 'package:color_canvas/firestore/firestore_data_schema.dart';
+import 'package:color_canvas/services/journey/journey_service.dart';
+import 'package:color_canvas/services/journey/default_color_story_v1.dart';
+import 'package:color_canvas/services/journey/journey_models.dart';
+import 'package:color_canvas/services/firebase_service.dart';
+import 'package:color_canvas/services/project_service.dart';
+import 'package:color_canvas/services/user_prefs_service.dart';
+import 'package:color_canvas/services/auth_guard.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+void main() {
+  tearDown(() {
+    createPaletteFn = FirebaseService.createPalette;
+    createProjectFn = ProjectService.create;
+    attachPaletteFn = ProjectService.attachPalette;
+    setLastProjectFn = UserPrefsService.setLastProject;
+    ensureSignedInFn = AuthGuard.ensureSignedIn;
+    getUidFn = () => FirebaseAuth.instance.currentUser?.uid;
+  });
+
+  testWidgets('saving palette updates journey and stores last project',
+      (tester) async {
+    createPaletteFn = ({
+      required userId,
+      required name,
+      required List<PaletteColor> colors,
+      List<String> tags = const [],
+      String notes = '',
+    }) async => 'pal1';
+    createProjectFn = ({
+      required ownerId,
+      String? title,
+      String? activePaletteId,
+      List<String> paletteIds = const [],
+    }) async => 'proj1';
+    attachPaletteFn = (pid, paletteId) async {};
+    String? storedProjectId;
+    setLastProjectFn = (pid, screen) async {
+      storedProjectId = pid;
+    };
+    ensureSignedInFn = (_) async {};
+    getUidFn = () => 'user1';
+
+    final journey = JourneyService.instance;
+    journey.state.value = JourneyState(
+      journeyId: defaultColorStoryJourneyId,
+      projectId: null,
+      currentStepId: 'roller.build',
+      completedStepIds: const ['interview.basic'],
+      artifacts: const {},
+    );
+
+    final paints = [
+      Paint(
+        id: 'p1',
+        brandId: 'b',
+        name: 'Red',
+        brandName: 'Brand',
+        code: 'R1',
+        hex: '#FF0000',
+        rgb: const [255, 0, 0],
+        lab: const [0, 0, 0],
+        lch: const [0, 0, 0],
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: SavePalettePanel(
+        paints: paints,
+        onSaved: () {},
+        onCancel: () {},
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField).first, 'My Palette');
+    await tester.tap(find.text('Save Palette'));
+    await tester.pumpAndSettle();
+
+    final state = journey.state.value!;
+    expect(state.artifacts['paletteId'], 'pal1');
+    expect(state.currentStepId, 'review.contrast');
+    expect(storedProjectId, 'proj1');
+  });
+}


### PR DESCRIPTION
## Summary
- add interview completion widget test
- persist paletteId to journey and project in SavePalettePanel
- add contrast review screen advancing journey

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b744100970832289442b1fc804d771