### PR TITLE
Persist journey artifacts and export guide

### DIFF
--- a/lib/screens/color_plan_screen.dart
+++ b/lib/screens/color_plan_screen.dart
@@ -3,6 +3,7 @@ import '../models/color_plan.dart';
 import '../services/color_plan_service.dart';
 import '../services/analytics_service.dart';
 import '../services/user_prefs_service.dart';
+import '../services/journey/journey_service.dart';
 
 class ColorPlanScreen extends StatefulWidget {
   final String projectId;
@@ -54,6 +55,9 @@ class _ColorPlanScreenState extends State<ColorPlanScreen> {
         paletteColorIds: widget.paletteColorIds!,
         context: {'lightingProfile': 'auto'},
       );
+
+      await JourneyService.instance
+          .completeCurrentStep(artifacts: {'planId': plan.id});
 
       // Telemetry - record plan generation details using structured params
       await AnalyticsService.instance.logEvent('plan_generated', {

--- a/lib/screens/create_screen.dart
+++ b/lib/screens/create_screen.dart
@@ -12,6 +12,7 @@ import 'roller_screen.dart';
 import 'visualizer_screen.dart';
 import 'learn_screen.dart';
 import 'review_contrast_screen.dart';
+import 'export_guide_screen.dart';
 
 /// ✨ Create Hub — Guided (orchestrated) + Tools tabs
 class CreateHubScreen extends StatefulWidget {
@@ -188,6 +189,15 @@ class _CreateHubScreenState extends State<CreateHubScreen> with TickerProviderSt
       case 'visualizer.photo':
       case 'visualizer.generate':
         _open(context, const VisualizerScreen());
+        break;
+      case 'guide.export':
+        final pid = s?.projectId;
+        if (pid != null) {
+          _open(context, ExportGuideScreen(projectId: pid));
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('No project found')));
+        }
         break;
       default:
         // default to Create hub or show dialog

--- a/lib/screens/export_guide_screen.dart
+++ b/lib/screens/export_guide_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../services/deliverable_service.dart';
+
+class ExportGuideScreen extends StatefulWidget {
+  final String projectId;
+  const ExportGuideScreen({super.key, required this.projectId});
+
+  @override
+  State<ExportGuideScreen> createState() => _ExportGuideScreenState();
+}
+
+class _ExportGuideScreenState extends State<ExportGuideScreen> {
+  String? _url;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final url = await DeliverableService.instance.exportGuide(widget.projectId);
+      if (mounted) setState(() => _url = url);
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Export Guide')),
+        body: Center(child: Text(_error!)),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Export Guide'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () => Share.share(_url!),
+          ),
+        ],
+      ),
+      body: WebView(
+        initialUrl: _url!,
+        javascriptMode: JavascriptMode.unrestricted,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   url_launcher: ^6.3.0
   firebase_remote_config: ^6.0.0
   timezone: ^0.10.1
+  webview_flutter: ^4.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- persist photoId and renderIds in visualizer and advance journey steps
- store planId after color plan creation and advance to export
- add DeliverableService and ExportGuide screen to generate/share PDF guide

## Testing
- ⚠️ `flutter pub get` *(flutter: command not found)*
- ⚠️ `flutter test` *(flutter: command not found)*
- ⚠️ `dart format lib/screens/visualizer_screen.dart lib/screens/color_plan_screen.dart lib/services/deliverable_service.dart lib/screens/export_guide_screen.dart lib/screens/create_screen.dart` *(dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74631f848832284e725e00d549f12